### PR TITLE
Add the snapshot command

### DIFF
--- a/Bin/Snapshot.php
+++ b/Bin/Snapshot.php
@@ -1,0 +1,198 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2015, Ivan Enderlin. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Devtools\Bin;
+
+use Hoa\Console;
+
+/**
+ * Class \Hoa\Devtools\Bin\Snapshot.
+ *
+ * Snapshot and generate changelog for the current repository root.
+ *
+ * @author     Ivan Enderlin <ivan.enderlin@hoa-project.net>
+ * @copyright  Copyright © 2007-2015 Ivan Enderlin.
+ * @license    New BSD License
+ */
+
+class Snapshot extends Console\Dispatcher\Kit {
+
+    /**
+     * Options description.
+     *
+     * @var \Hoa\Devtools\Bin\Requiresnapshot array
+     */
+    protected $options = [
+        ['break-bc',       Console\GetOption::NO_ARGUMENT, 'b'],
+        ['only-changelog', Console\GetOption::NO_ARGUMENT, 'c'],
+        ['help',           Console\GetOption::NO_ARGUMENT, 'h'],
+        ['help',           Console\GetOption::NO_ARGUMENT, '?']
+    ];
+
+
+
+    /**
+     * The entry method.
+     *
+     * @access  public
+     * @return  int
+     */
+    public function main ( ) {
+
+        $breakBC       = false;
+        $onlyChangelog = false;
+
+        while(false !== $c = $this->getOption($v)) switch($c) {
+
+            case '__ambiguous':
+                $this->resolveOptionAmbiguity($v);
+              break;
+
+            case 'b':
+                $breakBC = $v;
+              break;
+
+            case 'c':
+                $onlyChangelog = $v;
+              break;
+
+            case 'h':
+            case '?':
+            default:
+                return $this->usage();
+              break;
+        }
+
+        $this->parser->listInputs($repositoryRoot);
+
+        if(empty($repositoryRoot))
+            return $this->usage();
+
+        if(false === file_exists($repositoryRoot . DS . '.git'))
+            throw new Console\Exception(
+                '%s is not a valid Git repository.',
+                0, $repositoryRoot);
+
+        $tags = explode(
+            "\n",
+            Console\Processus::execute(
+                'git --git-dir=' . $repositoryRoot . '/.git ' .
+                    'tag'
+            )
+        );
+        rsort($tags);
+
+        list($currentMCN) = explode('.', $tags[0], 2);
+
+        if(true === $breakBC)
+            ++$currentMCN;
+
+        $newTag = $currentMCN . '.' . date('y.m.d');
+        $steps  = $tags;
+
+        if(false === $onlyChangelog) {
+
+            $answer = $this->readLine(
+                'Create tag ' . $newTag . ' for repository ' .
+                realpath($repositoryRoot) . '? [yes/no] '
+            );
+
+            if('yes' === $answer) {
+
+                Console\Processus::execute(
+                    'git --git-dir=' . $repositoryRoot . '/.git ' .
+                        'tag ' . $newTag
+                );
+                echo 'Done!', "\n";
+
+                array_unshift($steps, $newTag);
+            }
+            else
+                echo 'Aborted!', "\n";
+        }
+        else
+            array_unshift($steps, 'HEAD');
+
+        $changelog = null;
+
+        for($i = 0, $max = count($steps) - 1; $i < $max; ++$i) {
+
+            $fromStep = $steps[$i];
+            $toStep   = $steps[$i + 1];
+
+            $changelog .= '# ' . '`' . $fromStep . '`' . "\n\n" .
+                          Console\Processus::execute(
+                              'git --git-dir=' . $repositoryRoot . '/.git ' .
+                                  'log ' .
+                                      '--first-parent ' .
+                                      '--pretty="format:  * %h %s (%aN, %aI)" ' .
+                                      $fromStep . '...' . $toStep,
+                              false
+                          ) . "\n\n";
+
+            if($max < $i + 2)
+                $changelog .= '`' . $toStep . '`' . "\n\n" .
+                              '(first snapshot)';
+        }
+
+        echo "\n", $changelog;
+
+        return;
+    }
+
+    /**
+     * The command usage.
+     *
+     * @access  public
+     * @return  int
+     */
+    public function usage ( ) {
+
+        echo 'Usage   : devtools:snapshot <options> repository-root', "\n",
+             'Options :', "\n",
+             $this->makeUsageOptionsList([
+                 'b'    => 'Whether we have break the backward compatibility ' .
+                           'or not.',
+                 'c'    => 'Only print the changelog.',
+                 'help' => 'This help.'
+             ]), "\n";
+
+        return;
+    }
+}
+
+__halt_compiler();
+Snapshot and generate changelog for the current repository root.

--- a/Bin/Snapshot.php
+++ b/Bin/Snapshot.php
@@ -41,7 +41,7 @@ use Hoa\Console;
 /**
  * Class \Hoa\Devtools\Bin\Snapshot.
  *
- * Snapshot and generate changelog for the current repository root.
+ * Assistant to create a snapshot.
  *
  * @author     Ivan Enderlin <ivan.enderlin@hoa-project.net>
  * @copyright  Copyright © 2007-2015 Ivan Enderlin.
@@ -56,10 +56,9 @@ class Snapshot extends Console\Dispatcher\Kit {
      * @var \Hoa\Devtools\Bin\Requiresnapshot array
      */
     protected $options = [
-        ['break-bc',       Console\GetOption::NO_ARGUMENT, 'b'],
-        ['only-changelog', Console\GetOption::NO_ARGUMENT, 'c'],
-        ['help',           Console\GetOption::NO_ARGUMENT, 'h'],
-        ['help',           Console\GetOption::NO_ARGUMENT, '?']
+        ['break-bc', Console\GetOption::NO_ARGUMENT, 'b'],
+        ['help',     Console\GetOption::NO_ARGUMENT, 'h'],
+        ['help',     Console\GetOption::NO_ARGUMENT, '?']
     ];
 
 
@@ -72,8 +71,7 @@ class Snapshot extends Console\Dispatcher\Kit {
      */
     public function main ( ) {
 
-        $breakBC       = false;
-        $onlyChangelog = false;
+        $breakBC = false;
 
         while(false !== $c = $this->getOption($v)) switch($c) {
 
@@ -83,10 +81,6 @@ class Snapshot extends Console\Dispatcher\Kit {
 
             case 'b':
                 $breakBC = $v;
-              break;
-
-            case 'c':
-                $onlyChangelog = $v;
               break;
 
             case 'h':
@@ -121,54 +115,241 @@ class Snapshot extends Console\Dispatcher\Kit {
             ++$currentMCN;
 
         $newTag = $currentMCN . '.' . date('y.m.d');
-        $steps  = $tags;
 
-        if(false === $onlyChangelog) {
+        echo 'We are going to release this library together, by following ',
+             'these steps:', "\n",
+             '  1. tests must pass,', "\n",
+             '  2. updating the CHANGELOG.md file,', "\n",
+             '  3. commit the CHANGELOG.md file,', "\n",
+             '  4. creating a tag,', "\n",
+             '  5. pushing the tag,', "\n",
+             '  6. creating a release on Github.', "\n";
 
-            $answer = $this->readLine(
-                'Create tag ' . $newTag . ' for repository ' .
-                realpath($repositoryRoot) . '? [yes/no] '
-            );
+        $step = function ( $message, $task ) {
+
+            echo "\n\n";
+            Console\Cursor::colorize('foreground(black) background(yellow)');
+            echo 'Step “', $message, '”.';
+            Console\Cursor::colorize('normal');
+            echo "\n";
+
+            $answer = $this->readLine('Would you like to do this one: [yes/no] ');
 
             if('yes' === $answer) {
+
+                echo "\n";
+                $task();
+            }
+            else {
+
+                Console\Cursor::colorize('foreground(red)');
+                echo 'Aborted!', "\n";
+                Console\Cursor::colorize('normal');
+            }
+        };
+
+        $step(
+            'tests must pass',
+            function ( ) {
+
+                echo 'Tests must be green. Execute:', "\n",
+                     '    $ hoa test:run -d Test', "\n",
+                     'to run the tests.', "\n";
+                $this->readLine('Press Enter when it is green.');
+            }
+        );
+
+        $step(
+            'updating the CHANGELOG.md file',
+            function ( ) use ( $tags, $repositoryRoot ) {
+
+                $changelog = null;
+
+                for($i = 0, $max = count($tags) - 1; $i < $max; ++$i) {
+
+                    $fromStep = $tags[$i];
+                    $toStep   = $tags[$i + 1];
+
+                    $changelog .= '# ' . '`' . $fromStep . '`' . "\n\n" .
+                                  Console\Processus::execute(
+                                      'git --git-dir=' . $repositoryRoot . '/.git ' .
+                                          'log ' .
+                                              '--first-parent ' .
+                                              '--pretty="format:  * %h %s (%aN, %aI)" ' .
+                                              $fromStep . '...' . $toStep,
+                                      false
+                                  ) . "\n\n";
+
+                    if($max < $i + 2)
+                        $changelog .=  $toStep . "\n\n" .
+                                      '(first snapshot)';
+                }
+
+                echo $changelog;
+
+                return;
+            }
+        );
+
+        $step(
+            'commit the CHANGELOG.md file',
+            function ( ) {
+
+                echo 'Great! Now commit the CHANGELOG.md file!', "\n";
+                $this->readLine('Press Enter when it is done.');
+
+                return;
+            }
+        );
+
+        $step(
+            'creating a tag',
+            function ( ) use ( $breakBC, $step, $currentMCN, $repositoryRoot,
+                               $tags, $newTag ) {
+
+                if(true === $breakBC) {
+
+                    echo 'A BC break has been introduced, ',
+                         'few more steps are required:', "\n";
+
+                    $step(
+                        'update the composer.json file',
+                        function ( ) use ( $currentMCN ) {
+
+                            echo 'The `extra.branch-alias.dev-master` value ',
+                                 'must be set to `',
+                                 $currentMCN, '.x-dev`', "\n";
+                            $this->readLine('Press Enter when it is done.');
+                        }
+                    );
+
+                    $step(
+                        'open issues to update parent dependencies',
+                        function ( ) {
+
+                            echo 'Some libraries may depend on this one. ',
+                                 'Issues must be opened to update this ',
+                                 'dependency.', "\n";
+                            $this->readLine('Press Enter when it is done.');
+                        }
+                    );
+
+                    $step(
+                        'update the README.md file',
+                        function ( ) use ( $currentMCN ) {
+
+                            echo 'The installation Section must invite the ',
+                                 'user to install the version ',
+                                 '`~', $currentMCN, '.0`.', "\n";
+                            $this->readLine('Press Enter when it is done.');
+                        }
+                    );
+
+                    $step(
+                        'commit the composer.json and README.md files',
+                        function ( ) use ( $currentMCN ) {
+
+                            echo 'Great! Now commit the composer.json and ',
+                                 'README.md files!', "\n";
+                            $this->readLine('Press Enter when it is done.');
+                        }
+                    );
+                }
+
+                $status = Console\Processus::execute(
+                    'git --git-dir=' . $repositoryRoot . '/.git ' .
+                        'status ' .
+                            '--short'
+                );
+
+                if(!empty($status)) {
+
+                    Console\Cursor::colorize('foreground(white) background(red)');
+                    echo 'At least one file is not commited!';
+                    Console\Cursor::colorize('normal');
+                    echo "\n", '(tips: use `git stash` if it is not related ',
+                         'to this snapshot)', "\n";
+
+                    $this->readLine('Press Enter when everything is clean.');
+                }
+
+                echo 'Here is the list of tags:', "\n",
+                     '  * ', implode(',' . "\n" . '  * ', $tags), '.', "\n",
+                     'We are going to create the following tag: ',
+                     $newTag, '.', "\n";
+
+                $answer = $this->readLine('Is it correct? [yes/no] ');
+
+                if('yes' !== $answer)
+                    return;
 
                 Console\Processus::execute(
                     'git --git-dir=' . $repositoryRoot . '/.git ' .
                         'tag ' . $newTag
                 );
-                echo 'Done!', "\n";
-
-                array_unshift($steps, $newTag);
             }
-            else
-                echo 'Aborted!', "\n";
-        }
-        else
-            array_unshift($steps, 'HEAD');
+        );
 
-        $changelog = null;
+        $step(
+            'push the new snapshot',
+            function ( ) use ( $repositoryRoot ) {
 
-        for($i = 0, $max = count($steps) - 1; $i < $max; ++$i) {
+                Console\Cursor::colorize('foreground(white) background(red)');
+                echo 'This step ',
+                Console\Cursor::colorize('underlined');
+                echo 'must not';
+                Console\Cursor::colorize('!underlined');
+                echo ' be undo!';
+                Console\Cursor::colorize('normal');
 
-            $fromStep = $steps[$i];
-            $toStep   = $steps[$i + 1];
+                echo "\n";
 
-            $changelog .= '# ' . '`' . $fromStep . '`' . "\n\n" .
-                          Console\Processus::execute(
-                              'git --git-dir=' . $repositoryRoot . '/.git ' .
-                                  'log ' .
-                                      '--first-parent ' .
-                                      '--pretty="format:  * %h %s (%aN, %aI)" ' .
-                                      $fromStep . '...' . $toStep,
-                              false
-                          ) . "\n\n";
+                $i = 5;
+                while($i-- > 0) {
 
-            if($max < $i + 2)
-                $changelog .= '`' . $toStep . '`' . "\n\n" .
-                              '(first snapshot)';
-        }
+                    Console\Cursor::clear('↔');
+                    echo ($i + 1);
+                    sleep(1);
+                }
 
-        echo "\n", $changelog;
+                $remotes = Console\Processus::execute(
+                    'git --git-dir=' . $repositoryRoot . '/.git ' .
+                        'remote ' .
+                            '--verbose'
+                );
+
+                $gotcha = false;
+
+                foreach(explode("\n", $remotes) as $remote)
+                    if(0 !== preg_match('/(git@git.hoa-project.net:[^ ]+)/', $remote, $matches)) {
+
+                        $gotcha = true;
+
+                        break;
+                    }
+
+                if(false === $gotcha) {
+
+                    echo 'No remote has been found.';
+
+                    return;
+                }
+
+                echo "\n", 'To push tag, execute:', "\n",
+                     '    $ git push ', $matches[1], "\n";
+                $this->readLine('Press Enter when it is done.');
+            }
+        );
+
+        $step(
+            'create a release on Github',
+            function ( ) {
+
+                
+            }
+        );
+
+        echo "\n", '🍺 🍺 🍺', "\n";
 
         return;
     }
@@ -186,7 +367,6 @@ class Snapshot extends Console\Dispatcher\Kit {
              $this->makeUsageOptionsList([
                  'b'    => 'Whether we have break the backward compatibility ' .
                            'or not.',
-                 'c'    => 'Only print the changelog.',
                  'help' => 'This help.'
              ]), "\n";
 
@@ -195,4 +375,4 @@ class Snapshot extends Console\Dispatcher\Kit {
 }
 
 __halt_compiler();
-Snapshot and generate changelog for the current repository root.
+Assistant to create a snapshot.

--- a/Bin/Snapshot.php
+++ b/Bin/Snapshot.php
@@ -53,7 +53,7 @@ class Snapshot extends Console\Dispatcher\Kit {
     /**
      * Options description.
      *
-     * @var \Hoa\Devtools\Bin\Requiresnapshot array
+     * @var \Hoa\Devtools\Bin\Snapshot array
      */
     protected $options = [
         ['break-bc', Console\GetOption::NO_ARGUMENT, 'b'],

--- a/Bin/Snapshot.php
+++ b/Bin/Snapshot.php
@@ -251,7 +251,7 @@ class Snapshot extends Console\Dispatcher\Kit {
                                       'git --git-dir=' . $repositoryRoot . '/.git ' .
                                           'log ' .
                                               '--first-parent ' .
-                                              '--pretty="format:  * %h %s (%aN, %aI)" ' .
+                                              '--pretty="format:  * %s (%aN, %aI)" ' .
                                               $fromStep . '...' . $toStep,
                                       false
                                   ) . "\n\n";

--- a/Bin/Snapshot.php
+++ b/Bin/Snapshot.php
@@ -141,6 +141,8 @@ class Snapshot extends Console\Dispatcher\Kit {
                 '%s is not a valid Git repository.',
                 0, $repositoryRoot);
 
+        date_default_timezone_set('UTC');
+
         $allTags = $tags = explode(
             "\n",
             Console\Processus::execute(

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "hoa/console"   : "~2.0",
         "hoa/core"      : "~2.0",
         "hoa/dispatcher": "~0.0",
+        "hoa/file"      : "~0.0",
         "hoa/router"    : "~2.0"
     },
     "autoload": {


### PR DESCRIPTION
Fix https://github.com/hoaproject/Devtools/pull/3.

Example of usage on `Hoa\Ruler`.
# Only compute the `CHANGELOG`

``` sh
$ hoa devtools:snapshot --only-changelog .
```

Here is the result:

> # `HEAD`
> - d156dca Add tests for the dynamic callable. (Ivan Enderlin, 2015-02-05T17:13:12+01:00)
> # `1.15.02.05`
> - 55e35f5 Fix #50 on Github. (Ivan Enderlin, 2015-02-05T16:50:13+01:00)
> - a191132 Add tests for the context. (Ivan Enderlin, 2015-02-05T16:49:30+01:00)
> # `1.15.02.02`
> - 1b5083f s/interprete/interpret/ (Ivan Enderlin, 2015-02-02T11:31:29+01:00)
> - e61fbb8 Apply reviews of @stephpy and @Savageman. (Ivan Enderlin, 2015-02-02T11:30:24+01:00)
> - 29f66fe Update Ruler.php (simkimsia, 2015-01-16T22:22:18+08:00)
> - 8c100b5 Merge branch 'pr/42' into incoming (Ivan Enderlin, 2015-01-15T13:34:30+01:00)
> - 38d59f8 Happy new year! (Ivan Enderlin, 2015-01-05T14:47:59+01:00)
> # `1.14.12.10`
> - 2039f8e Move to PSR-4. (Ivan Enderlin, 2014-12-09T18:45:18+01:00)
> # `1.14.12.09`
> - ad32e48 Merge branch 'pr/36' into incoming (Ivan Enderlin, 2014-12-09T18:25:25+01:00)
> - 32f6b1e Format namespace. (Ivan Enderlin, 2014-12-08T14:04:08+01:00)
> - f21c96c Require hoa/test. (Alexis von Glasow, 2014-11-26T13:21:41+01:00)
> - 07bf8b5 Hoa\Visitor has been finalized. (Ivan Enderlin, 2014-11-15T22:28:07+01:00)
> # `1.14.11.10`
> - abc2201 Avoid collisions with user-defined operators… (Ivan Enderlin, 2014-11-10T15:43:04+01:00)
> # `1.14.11.09`
> - d13f1e7 Merge branch 'pr/16' into incoming (Ivan Enderlin, 2014-11-07T09:29:55+01:00)
> - 3072567 Add tests for the documentation. (Ivan Enderlin, 2014-09-26T09:23:44+02:00)
> # `1.14.09.25`
> - 60263c8 Fix Fatal error. (Stéphane PY, 2014-09-25T12:22:18+02:00)
> - 5d24414 Merge branch 'pr/20' into incoming (Ivan Enderlin, 2014-09-23T16:06:06+02:00)
> - b1ead69 Merge branch 'incoming' (Ivan Enderlin, 2014-09-23T15:58:55+02:00)
> # `1.14.09.23`
> - 5a76729 First tag :-). (Ivan Enderlin, 2014-09-23T15:41:11+02:00)
> - b51ebd6 Finalized! (Ivan Enderlin, 2014-09-23T15:37:04+02:00)
> - d05bd3b Remove from/import and update to PHP5.4. (Ivan Enderlin, 2014-09-23T15:32:36+02:00)
> - 602a7c6 Declare array with […] and not (…). (Ivan Enderlin, 2014-09-23T14:58:18+02:00)
> # `0.14.09.17`
> - 9ca61b5 Drop PHP5.3. (Ivan Enderlin, 2014-09-17T17:13:16+02:00)
> - 83db019 Add the installation section. (Ivan Enderlin, 2014-09-17T17:13:05+02:00)
> 
> `0.14.09.16`
> 
> (first snapshot)

We have only the first commit of every merges, no the children. This is a little bit annoying when the merge subject is “Merge branch 'pr/20' into incoming” for instance. In this case, we will edit the `CHANGELOG` manually because we will **not** rebase the Git history. To achieve that, I have to add an option to select a subset of tags to generate the `CHANGELOG`.
# Create a snapshot

Else, if we would like to tag:

``` sh
$ hoa devtools:snapshot .
Create tag 1.15.02.05 for repository /Users/Hywan/Development/Hoa/Project/Central/Hoa/Ruler? [yes/no] no
Aborted!

…
```

`…` is the `CHANGELOG`.
# Create a snapshot that breaks BC

If we broke the BC, we will have:

``` sh
$ hoa devtools:snapshot --break-bc .
Create tag 2.15.02.05 for repository /Users/Hywan/Development/Hoa/Project/Central/Hoa/Ruler? [yes/no] no
Aborted!

…
```

**It does not push for you** and hopefully :-).

I don't know if “tagging” or “changeloging” must be exclusive tasks. I think it's better. First, generate the `CHANGELOG` (commit it, not automatic), then create the tag.

Thoughts?

Thanks to @camael24 and @Pierozi for their help!
