### PR TITLE
Only compute the documentation once

### DIFF
--- a/Bin/Documentation.php
+++ b/Bin/Documentation.php
@@ -187,11 +187,15 @@ class Documentation extends Console\Dispatcher\Kit
                 $vendors[$vendor] = [];
             }
 
-            $vendors[$vendor][] = [
+            $vendors[$vendor][$library] = [
                 'library'  => $library,
                 'vendor'   => $vendor,
                 'fullname' => $vendor . '\\' . $library
             ];
+        }
+
+        foreach ($vendors as $vendor => &$libraries) {
+            $libraries = array_values($libraries);
         }
 
         $layout = new File\Read('hoa://Library/Devtools/Resource/Documentation/Layout.xyl');


### PR DESCRIPTION
Fix #18.

If we find twice the same library, it was computed twice. This caused an issue. For instance, if we are inside a library that has a documentation, it will be scanned twice: First time because we scan the current library and second time because we scan `hoa://Library`.

This patch fixes this issue by using the hashmap unicity property of PHP arrays and by reformatting the `$vendors` array for XYL.
