### PR TITLE
Use a default value for `--directories` option.

### DIFF
--- a/Bin/Documentation.php
+++ b/Bin/Documentation.php
@@ -131,6 +131,10 @@ class Documentation extends Console\Dispatcher\Kit
             return;
         }
 
+        if (empty($directories)) {
+            $directories[] = getcwd();
+        }
+
         clearstatcache(true);
 
         $workspace .= DS . $lang;


### PR DESCRIPTION
Allow to run the command directly inside a library folder.

Must fix the #32 issue.
