### PR TITLE
Snapshot: Signed tag and more secure Github access

### DIFF
--- a/Bin/Snapshot.php
+++ b/Bin/Snapshot.php
@@ -455,7 +455,7 @@ class Snapshot extends Console\Dispatcher\Kit
 
                 Console\Processus::execute(
                     'git --git-dir=' . $repositoryRoot . '/.git ' .
-                        'tag ' . $newTag
+                        'tag -s ' . $newTag
                 );
             }
         );

--- a/Bin/Snapshot.php
+++ b/Bin/Snapshot.php
@@ -540,9 +540,7 @@ class Snapshot extends Console\Dispatcher\Kit
                     'body'     => $body
                 ]);
 
-                $username = $this->readLine('Username: ');
-                $password = $this->readPassword('Password: ');
-                $auth     = base64_encode($username . ':' . $password);
+                $authToken = $this->readLine('Authentication token: ');
 
                 $context = stream_context_create([
                     'http' => [
@@ -552,7 +550,7 @@ class Snapshot extends Console\Dispatcher\Kit
                                      'Accept: application/json' . CRLF .
                                      'Content-Type: application/json' . CRLF .
                                      'Content-Length: ' . strlen($output) . CRLF .
-                                     'Authorization: Basic ' . $auth . CRLF,
+                                     'Authorization: token ' . $authToken . CRLF,
                         'content' => $output
                     ]
                 ]);


### PR DESCRIPTION
1. Tags are now signed,
2. Github token must be used instead of a basic auth (with 2FA for instance).