### PR TITLE
Documentation: Update an exception message

### DIFF
--- a/Bin/Documentation.php
+++ b/Bin/Documentation.php
@@ -164,9 +164,10 @@ class Documentation extends Console\Dispatcher\Kit
 
             if (false === is_dir($_location)) {
                 throw new Console\Exception(
-                    'Directory %s does not contain documentation.',
+                    'There is no documentation for the %s library ' .
+                    '(checked directory %s).',
                     1,
-                    $location
+                    [basename($location), $_location]
                 );
             }
 


### PR DESCRIPTION
Fix https://github.com/hoaproject/Devtools/issues/40.

It is better to say that there is no documentation than the directory is not found. The user clearly understands what happens this way.