### PR TITLE
fix(php-cs-fixer) Change method to apply fix with php-cs-fixer

### DIFF
--- a/Resource/PHPCSFixer/Fixer/Author.php
+++ b/Resource/PHPCSFixer/Fixer/Author.php
@@ -52,7 +52,7 @@ use SplFileInfo;
  */
 class Author extends AbstractFixer
 {
-    public function fix(SplFileInfo $file, Tokens $tokens)
+    protected function applyfix(SplFileInfo $file, Tokens $tokens)
     {
         foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
             $docBlock    = new DocBlock($token->getContent());

--- a/Resource/PHPCSFixer/Fixer/ControlFlowStatement.php
+++ b/Resource/PHPCSFixer/Fixer/ControlFlowStatement.php
@@ -52,7 +52,7 @@ use SplFileInfo;
  */
 class ControlFlowStatement extends AbstractFixer
 {
-    public function fix(SplFileInfo $file, Tokens $tokens)
+    protected function applyfix(SplFileInfo $file, Tokens $tokens)
     {
         for ($index = 0, $limit = $tokens->count(); $index < $limit; ++$index) {
             $token = $tokens[$index];

--- a/Resource/PHPCSFixer/Fixer/Copyright.php
+++ b/Resource/PHPCSFixer/Fixer/Copyright.php
@@ -52,7 +52,7 @@ use SplFileInfo;
  */
 class Copyright extends AbstractFixer
 {
-    public function fix(SplFileInfo $file, Tokens $tokens)
+    protected function applyfix(SplFileInfo $file, Tokens $tokens)
     {
         $thisYear = date('Y');
 

--- a/Resource/PHPCSFixer/Fixer/NoBlankLinesBeforeEntity.php
+++ b/Resource/PHPCSFixer/Fixer/NoBlankLinesBeforeEntity.php
@@ -51,7 +51,7 @@ use SplFileInfo;
  */
 class NoBlankLinesBeforeEntity extends AbstractLinesBeforeNamespaceFixer
 {
-    public function fix(SplFileInfo $file, Tokens $tokens)
+    protected function applyfix(SplFileInfo $file, Tokens $tokens)
     {
         foreach ($tokens as $index => $token) {
             if ($token->isGivenKind(T_CLASS) ||

--- a/Resource/PHPCSFixer/Fixer/PhpdocConstructorReturn.php
+++ b/Resource/PHPCSFixer/Fixer/PhpdocConstructorReturn.php
@@ -54,7 +54,7 @@ class PhpdocConstructorReturn extends AbstractFixer
 {
     const CONSTRUCTOR_NAME = '__construct';
 
-    public function fix(SplFileInfo $file, Tokens $tokens)
+    protected function applyfix(SplFileInfo $file, Tokens $tokens)
     {
         $function = $tokens->findSequence([
             [T_FUNCTION],

--- a/Resource/PHPCSFixer/Fixer/PhpdocThrows.php
+++ b/Resource/PHPCSFixer/Fixer/PhpdocThrows.php
@@ -52,7 +52,7 @@ use SplFileInfo;
  */
 class PhpdocThrows extends AbstractFixer
 {
-    public function fix(SplFileInfo $file, Tokens $tokens)
+    protected function applyfix(SplFileInfo $file, Tokens $tokens)
     {
         foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
             $docBlock    = new DocBlock($token->getContent());

--- a/Resource/PHPCSFixer/Fixer/PhpdocVar.php
+++ b/Resource/PHPCSFixer/Fixer/PhpdocVar.php
@@ -60,7 +60,7 @@ use SplFileInfo;
  */
 class PhpdocVar extends AbstractFixer
 {
-    public function fix(SplFileInfo $file, Tokens $tokens)
+    protected function applyfix(SplFileInfo $file, Tokens $tokens)
     {
         foreach ($tokens->findGivenKind(T_DOC_COMMENT) as $token) {
             $docBlock    = new DocBlock($token->getContent());


### PR DESCRIPTION
Replace the method fix to method applyfix which is now used by
php-cs-fixer for apply custom fix.

Address hoaproject/Devtools#46.