### PR TITLE
Update the `devtools:snapshot` command to use structured commit information when generating changelog.

### DIFF
--- a/Bin/Snapshot.php
+++ b/Bin/Snapshot.php
@@ -49,19 +49,21 @@ use Hoa\File;
  */
 class Snapshot extends Console\Dispatcher\Kit
 {
-    /**
-     * User friendly labels for changelog themes.
-     *
-     * @const
-     */
-    public const CHANGELOG_THEMES = [];
+    public const CHANGELOG_THEMES = [
+        'chore' => 'Chore',
+        'fix'   => 'Bug fixes',
+        'feat'  => 'New features',
+        'depr'  => 'Deprecated features',
+        'sec'   => 'Security',
+        'doc'   => 'Documentation improvements',
+        'test'  => 'Test improvements',
+        'undef' => 'Miscellaneous'
+    ];
 
-    /**
-     * User friendly labels for changelog themes.
-     *
-     * @const
-     */
-    public const CHANGELOG_KEYWORDS = [];
+    public const CHANGELOG_KEYWORDS = [
+        'ci'  => 'Continuous Integration',
+        'php' => 'PHP'
+    ];
 
     /**
      * Options description.

--- a/Bin/Snapshot.php
+++ b/Bin/Snapshot.php
@@ -71,13 +71,14 @@ class Snapshot extends Console\Dispatcher\Kit
      * @var array
      */
     protected $options = [
-        ['only-changelog',      Console\GetOption::NO_ARGUMENT,       'c'],
-        ['only-tag',            Console\GetOption::NO_ARGUMENT,       't'],
-        ['only-github-release', Console\GetOption::NO_ARGUMENT,       'g'],
-        ['break-bc',            Console\GetOption::NO_ARGUMENT,       'b'],
-        ['minimum-tag',         Console\GetOption::REQUIRED_ARGUMENT, 'm'],
-        ['help',                Console\GetOption::NO_ARGUMENT,       'h'],
-        ['help',                Console\GetOption::NO_ARGUMENT,       '?']
+        ['only-changelog',          Console\GetOption::NO_ARGUMENT,       'c'],
+        ['without-typed-commits',   Console\GetOption::NO_ARGUMENT,       'w'],
+        ['only-tag',                Console\GetOption::NO_ARGUMENT,       't'],
+        ['only-github-release',     Console\GetOption::NO_ARGUMENT,       'g'],
+        ['break-bc',                Console\GetOption::NO_ARGUMENT,       'b'],
+        ['minimum-tag',             Console\GetOption::REQUIRED_ARGUMENT, 'm'],
+        ['help',                    Console\GetOption::NO_ARGUMENT,       'h'],
+        ['help',                    Console\GetOption::NO_ARGUMENT,       '?']
     ];
 
 
@@ -142,6 +143,11 @@ class Snapshot extends Console\Dispatcher\Kit
 
                 case 'm':
                     $minimumTag = $v;
+
+                    break;
+
+                case 'w':
+                    $withoutTypedCommits = true;
 
                     break;
 
@@ -643,6 +649,8 @@ class Snapshot extends Console\Dispatcher\Kit
                 'b'    => 'Whether we have break the backward compatibility ' .
                           'or not.',
                 'c'    => 'Only do steps related to the CHANGELOG.md file.',
+                'w'    => 'Only export typed commits to the CHANGELOG.md ' .
+                          'file and discard others.',
                 't'    => 'Only do steps related to the tag.',
                 'g'    => 'Only do steps related to Github release.',
                 'm'    => 'Set the minimum tag (default: the latest, often ' .


### PR DESCRIPTION
With the RFC hoaproject/Central#61 we introduce structured commits with the pattern : `type(scope) title`.

This PR update the `changelog` step to use this new information when generating the CHANGELOG.md file.

At the moment, all the commits are kept in the resulting file. The non structured ones are stored inside a specific "Commits" sections.

Here an example with the latest hoaproject/Websocket tag :

> # 3.18.01.23
> 
> ## Quality
> 
> ### Composer
> 
>  * Use `dev-master` dependencies. (Ivan Enderlin, 2018-01-23T10:42:02+01:00)
>  * add PHP version requirement (Alexis von Glasow, 2017-08-04T13:48:47+02:00)
> 
> ### PHP
> 
>  * Update to PHP 7. (Ivan Enderlin, 2017-11-10T10:30:28+01:00)
>  * Update to PHP 7. (Ivan Enderlin, 2017-11-10T10:13:42+01:00)
>  * Update to PHP 7. (Ivan Enderlin, 2017-11-08T15:55:02+01:00)
>  * Fix composer. (Ivan Enderlin, 2017-11-08T15:35:39+01:00)
>  * Update to PHP 7. (Ivan Enderlin, 2017-11-08T15:33:56+01:00)
> 
> ### CI
> 
>  * Drop HHVM support. (Stéphane HULARD, 2017-07-07T11:51:42+02:00)
> 
> ## Commits
> 
>   * Connection: Add `close-before` event. (Metalaka, 2017-03-30T21:37:26+02:00)
>   * Fire close event before closing and on error (jmdevince, 2016-04-28T15:15:33-05:00)
>   * Merge branch 'incoming' into issue_58 (Ivan Enderlin, 2017-03-24T15:18:21+01:00)
>   * Connection: If a normal close fails, no error. (Ivan Enderlin, 2016-08-04T08:32:03+02:00)
>   * Connection: Ensure disconnection on closing. (Ivan Enderlin, 2016-08-04T08:29:50+02:00)