### PR TITLE
feat(devtools) Adding a command to create file from templates when we…

### DIFF
--- a/Bin/Project.php
+++ b/Bin/Project.php
@@ -1,0 +1,139 @@
+<?php
+
+/**
+ * Hoa
+ *
+ *
+ * @license
+ *
+ * New BSD License
+ *
+ * Copyright © 2007-2018, Hoa community. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Hoa nor the names of its contributors may be
+ *       used to endorse or promote products derived from this software without
+ *       specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Hoa\Devtools\Bin;
+
+use Hoa\Console;
+
+/**
+ * Class \Hoa\Devtools\Bin\Project.
+ *
+ * Paste something somewhere.
+ *
+ * @copyright  Copyright © 2007-2018 Hoa community
+ * @license    New BSD License
+ */
+class Project extends Console\Dispatcher\Kit
+{
+	/**
+	 * Options description.
+	 *
+	 * @var array
+	 */
+	protected $options = [
+		['name', Console\GetOption::REQUIRED_ARGUMENT, 'n'],
+		['help', Console\GetOption::NO_ARGUMENT, 'h'],
+		['help', Console\GetOption::NO_ARGUMENT, '?']
+	];
+
+	/**
+	 * The entry method.
+	 */
+	public function main()
+	{
+		$name = 'Foo';
+		while (false !== $c = $this->getOption($v)) {
+			switch ($c) {
+				case 'n':
+					$name = $v;
+
+					break;
+
+				case 'h':
+				case '?':
+					return $this->usage();
+
+				case '__ambiguous':
+					$this->resolveOptionAmbiguity($v);
+
+					break;
+			}
+		}
+
+		$this->filesCreate($name);
+
+		return;
+	}
+
+	/**
+	 * The command usage.
+	 */
+	public function usage()
+	{
+		echo
+		'Usage   : devtools:project <options>', "\n",
+		'Options :', "\n",
+		$this->makeUsageOptionsList([
+            'n'    => 'Name of the library.',
+            'help' => 'This help.'
+        ]), "\n";
+
+		return;
+	}
+
+	protected function filesCreate($libName)
+	{
+		$iterator = new \GlobIterator(__DIR__ . '/../Resource/templates/*.*.php');
+		foreach ($iterator as $fileinfo)
+		{
+			$filename = $fileinfo->getBasename('.php');
+			if (file_exists($filename) && !$this->override($filename))
+			{
+				continue;
+			}
+
+			$template = file_get_contents($fileinfo->getPathname());
+
+			$key = ['{LIB_NAME}', '{LIB_NAME_LOWER}'];
+			$value = [$libName, strtolower($libName)];
+			$content = str_replace($key, $value, $template);
+			file_put_contents($filename, $content);
+		}
+
+		return;
+	}
+
+	protected function override($filename)
+	{
+		echo 'Override existing file: "', $filename , '" (y/n)?', "\n";
+		$rl = new Console\Readline\Readline();
+		$override = strtolower(trim($rl->readLine('> ')));
+		return $override == 'y';
+	}
+}
+
+__halt_compiler();
+Initalize a project with standard files

--- a/Resource/templates/README.md.php
+++ b/Resource/templates/README.md.php
@@ -1,0 +1,92 @@
+<p align="center">
+	<img src="https://static.hoa-project.net/Image/Hoa.svg" alt="Hoa" width="250px" />
+</p>
+
+---
+
+<p align="center">
+	<a href="https://travis-ci.org/hoaproject/{LIB_NAME}"><img src="https://img.shields.io/travis/hoaproject/{LIB_NAME}/master.svg" alt="Build status" /></a>
+	<a href="https://coveralls.io/github/hoaproject/{LIB_NAME}?branch=master"><img src="https://img.shields.io/coveralls/hoaproject/{LIB_NAME}/master.svg" alt="Code coverage" /></a>
+	<a href="https://packagist.org/packages/hoa/{LIB_NAME_LOWER}"><img src="https://img.shields.io/packagist/dt/hoa/{LIB_NAME_LOWER}.svg" alt="Packagist" /></a>
+	<a href="https://hoa-project.net/LICENSE"><img src="https://img.shields.io/packagist/l/hoa/{LIB_NAME}.svg" alt="License" /></a>
+</p>
+<p align="center">
+	Hoa is a <strong>modular</strong>, <strong>extensible</strong> and
+	<strong>structured</strong> set of PHP libraries.<br />
+	Moreover, Hoa aims at being a bridge between industrial and research worlds.
+</p>
+
+# Hoa\{LIB_NAME}
+
+[![Help on IRC](https://img.shields.io/badge/help-%23hoaproject-ff0066.svg)](https://webchat.freenode.net/?channels=#hoaproject)
+[![Help on Gitter](https://img.shields.io/badge/help-gitter-ff0066.svg)](https://gitter.im/hoaproject/central)
+[![Documentation](https://img.shields.io/badge/documentation-hack_book-ff0066.svg)](https://central.hoa-project.net/Documentation/Library/{LIB_NAME})
+[![Board](https://img.shields.io/badge/organisation-board-ff0066.svg)](https://waffle.io/hoaproject/{LIB_NAME_LOWER})
+
+<The description of the library>
+
+[Learn more](https://central.hoa-project.net/Documentation/Library/{LIB_NAME}).
+
+## Installation
+
+With [Composer](https://getcomposer.org/), to include this library into
+your dependencies, you need to
+require [`hoa/{LIB_NAME_LOWER}`](https://packagist.org/packages/hoa/{LIB_NAME_LOWER}):
+
+```sh
+$ composer require hoa/{LIB_NAME_LOWER}
+```
+
+For more installation procedures, please read [the Source page](https://hoa-project.net/Source.html).
+
+## Testing
+
+Before running the test suites, the development dependencies must be installed:
+
+```sh
+$ composer install
+```
+
+Then, to run all the test suites:
+
+```sh
+$ vendor/bin/hoa test:run
+```
+
+For more information, please read the [contributor guide](https://hoa-project.net/Literature/Contributor/Guide.html).
+
+## Quick usage
+
+<Description of the usage of the library>
+
+## Documentation
+
+The [hack book of `Hoa\{LIB_NAME}`](https://central.hoa-project.net/Documentation/Library/{LIB_NAME}) contains
+detailed information about how to use this library and how it works.
+
+To generate the documentation locally, execute the following commands:
+
+```sh
+$ composer require --dev hoa/devtools
+$ vendor/bin/hoa devtools:documentation --open
+```
+
+More documentation can be found on the project's website:
+[hoa-project.net](https://hoa-project.net/).
+
+## Getting help
+
+There are mainly two ways to get help:
+
+* On the [`#hoaproject`](https://webchat.freenode.net/?channels=#hoaproject) IRC channel,
+* On the forum at [users.hoa-project.net](https://users.hoa-project.net).
+
+## Contribution
+
+Do you want to contribute? Thanks! A detailed [contributor guide](https://hoa-project.net/Literature/Contributor/Guide.html) explains
+everything you need to know.
+
+## License
+
+Hoa is under the New BSD License (BSD-3-Clause). Please, see
+[`LICENSE`](https://hoa-project.net/LICENSE) for details.


### PR DESCRIPTION
If we create a new library we need to initalize a series of files. This is the begining of that part.

I see a lot of potential improvements, but the idea is to have a base to build on.

```
vendor/bin/hoa devtools:project -n NewLibrary
```
Will create the base of the readme file, based on the common template. If the file exist, it will ask about it and offer the possibility to ovveride it.